### PR TITLE
[LV3] 섬 연결하기

### DIFF
--- a/김현경/[LV3] 섬 연결하기.py
+++ b/김현경/[LV3] 섬 연결하기.py
@@ -1,0 +1,24 @@
+def find(parent, x):
+    if parent[x] != x:
+        parent[x] = find(parent, parent[x])
+    return parent[x]
+    
+def union(parent, a, b):
+    a = find(parent, a)
+    b = find(parent, b)
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+    
+def solution(n, costs):
+    total_cost = 0
+    parent = [i for i in range(n)]
+    costs.sort(key=lambda x: x[2])
+    
+    for cost in costs:
+        a, b, c = cost
+        if find(parent, a) != find(parent, b):
+            union(parent, a, b)
+            total_cost += c
+    return total_cost


### PR DESCRIPTION
## 풀이
최소 비용 신장 트리를 찾는 문제로 크루스칼 알고리즘 사용

- `find` 함수
    - 특정 노드 `x`의 루트를 찾는다.
    - 경로 압축을 통해 부모를 루트 노드로 설정하여 탐색 시간을 줄인다.
- `union` 함수
    - 두 노드 `a`와 `b`가 각각 속한 집합을 합친다.
    - `a`와 `b`의 루트를 찾아 작은 값의 노드를 부모로 설정하여 두 집합을 하나로 만든다.
- `solution` 함수
    - `parent`에 각 섬은 자기 자신을 부모로 설정해줌
    - 비용을 기준으로 오름차순 정렬
    - 비용이 가장 작은 간선부터 순회
        - `find` 함수를 통해 두 섬이 서로 다른 집합에 속해 있는지 확인
	- 다른 집합에 속해있다면 `union` 함수를 통해 두 섬을 같은 집합으로 합치고 비용을 `total_cost`에 추가
    - 모든 간선을 다 확인하고 `total_cost` 반환
    
    
<img width="276" alt="섬연결하기" src="https://github.com/user-attachments/assets/f71d6b4c-a6ba-4970-8328-8df056c42e52">
