### PR TITLE
[LV3] 섬 연결하기

### DIFF
--- a/김은지/[LV3] 섬 연결하기.js
+++ b/김은지/[LV3] 섬 연결하기.js
@@ -1,0 +1,125 @@
+// 크루스칼
+function find(parent, x) {
+  if (parent[x] === x) {
+    return x;
+  }
+
+  return (parent[x] = find(parent, parent[x]));
+}
+
+function union(parent, a, b) {
+  a = find(parent, a);
+  b = find(parent, b);
+
+  if (a < b) {
+    parent[b] = a;
+  } else {
+    parent[a] = b;
+  }
+}
+
+function isCycle(parent, a, b) {
+  return find(parent, a) === find(parent, b);
+}
+
+function kruskal(n, edges) {
+  edges.sort((a, b) => a[2] - b[2]);
+  const parent = Array.from({ length: n }, (_, i) => i);
+
+  let totalCost = 0;
+
+  edges.forEach(([node1, node2, cost]) => {
+    if (!isCycle(parent, node1, node2)) {
+      union(parent, node1, node2);
+      totalCost += cost;
+    }
+  });
+
+  return totalCost;
+}
+
+function solution(n, costs) {
+  return kruskal(n, costs);
+}
+
+// 프림 알고리즘
+// function getGraph(n, costs) {
+//     const graph = Array.from({ length: n }, () => []);
+
+//     costs.forEach(([src, dst, cost]) => {
+//         graph[src].push({ node: dst, cost });
+//         graph[dst].push({ node: src, cost });
+//     });
+
+//     return graph;
+// }
+
+// function prim(n, start, graph) {
+//     const visited = Array(n).fill(false);
+//     let totalCost = 0;
+//     const stack = [{ node: start, cost: 0 }];
+
+//     while (stack.length > 0) {
+//         stack.sort((a, b) => b.cost - a.cost);
+//         const { node: src, cost: srcCost } = stack.pop();
+
+//         if (visited[src]) continue;
+//         visited[src] = true;
+//         totalCost += currentCost;
+
+//         for (const { node: dst, cost } of graph[src]) {
+//             if (!visited[dst]) {
+//                 stack.push({ node: dst, cost });
+//             }
+//         }
+//     }
+
+//     return totalCost;
+// }
+
+// function solution(n, costs) {
+//     const graph = getGraph(n, costs);
+//     return prim(n, 0, graph);
+// }
+
+// 다익스트라 변형
+// function getGraph(n, costs) {
+//   const graph = Array.from({ length: n }, () => []);
+
+//   costs.forEach(([src, dst, cost]) => {
+//     graph[src].push({ node: dst, cost });
+//     graph[dst].push({ node: src, cost });
+//   });
+
+//   return graph;
+// }
+
+// function dijkstra(n, start, graph) {
+//   const distance = Array(n).fill(Infinity);
+//   const visited = Array(n).fill(false);
+//   distance[start] = 0;
+
+//   const stack = [{ node: start, cost: 0 }];
+//   while (stack.length > 0) {
+//     stack.sort((a, b) => b.cost - a.cost);
+//     const { node: src, cost: srcCost } = stack.pop();
+
+//     if (visited[src]) continue;
+//     visited[src] = true;
+
+//     for (const { node: dst, cost } of graph[src]) {
+//       if (!visited[dst] && distance[dst] > cost) {
+//         distance[dst] = cost;
+//         stack.push({ node: dst, cost: cost });
+//       }
+//     }
+//   }
+
+//   return distance;
+// }
+
+// function solution(n, costs) {
+//   const graph = getGraph(n, costs);
+
+//   return Math.min(...[...Array(n).keys()].map((node) => dijkstra(n, node, graph).reduce((a, b) => a + b, 0)));
+// }


### PR DESCRIPTION
> [문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/42861?language=javascript)
> 시간 소요 `80+분/80분`
> 시간 복잡도 `/O(NlogN)`

<img width="200" alt="image" src="https://github.com/user-attachments/assets/f6904cc8-a27b-4a70-98b3-b0e6039c8493">

## 풀이

- 먼저 가중치 기준으로 정렬을 합니다.
- 정렬된 간선을 순회하면서
  - 불필요한 사이클이 만들어지지 않는다면 union으로 두 정점을 연결해주는 작업을 수행합니다.
  - union에서는 find를 활용해 각 노드의 조상 노드를 찾아주고, 일관적인 트리 구성을 위해 번호가 작은 노드가 부모 노드가 되도록 해줍니다.
  - 각 노드를 연결 후 연결 간선 가중치를 totalCost에 더해 업데이트 해줍니다.
  - 이 과정을 반복하면 최종 totalCost를 구할 수 있습니다.

## 기타
- 처음에 가중치가 있어서 다익스트라로 접근했다가 특정 노드까지의 최단 경로를 구하는 게 아니라 각 노드를 모두 거치는 최단 길이를 구해야하기 때문에 다른 접근 방법이 필요하였습니다.
- [해당 글](https://transferhwang.tistory.com/434)을 참고하여 다익스트라의 변형 형태로 1차적으로 풀었습니다.
- 그 후 다익스트라 변형과 유사하지만 distance를 사용하지 않고, 최단 길이를 매번 업데이트 해주는 프림 알고리즘으로 다시 풀어보았습니다.
- 마지막으로 최종 풀이인 크루스칼 알고리즘으로 풀어보았습니다.