### PR TITLE
[LV3] 네트워크

### DIFF
--- a/김은지/[LV3] 네트워크.js
+++ b/김은지/[LV3] 네트워크.js
@@ -1,0 +1,38 @@
+function getGraph(n, computers) {
+  const graph = Array.from({ length: n }, () => []);
+  computers.forEach((dsts, srcId) => {
+    dsts.forEach((dst, dstId) => {
+      if (dst === 1 && srcId !== dstId) graph[srcId].push(dstId);
+    });
+  });
+  return graph;
+}
+
+function dfs(start, graph, visited) {
+  const stack = [start];
+  visited.add(start);
+
+  while (stack.length > 0) {
+    const src = stack.pop();
+
+    for (const dst of graph[src]) {
+      if (visited.has(dst)) continue;
+      stack.push(dst);
+      visited.add(dst);
+    }
+  }
+}
+
+function solution(n, computers) {
+  const graph = getGraph(n, computers);
+  const visited = new Set();
+
+  let network = 0;
+  for (let node = 0; node < n; node++) {
+    if (visited.has(node)) continue;
+    network++;
+    dfs(node, graph, visited);
+  }
+
+  return network;
+}


### PR DESCRIPTION
> [문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/43162)
> 시간 소요 `15분/60분`
> 시간 복잡도 `/O(N)`

<img width="200" alt="image" src="https://github.com/user-attachments/assets/f66bd6ff-2d20-42f5-b773-fd2fa3d9369b">

## 풀이

- 특정 지점으로 부터 dfs 혹은 bfs를 돌면서 방문을 해주면 연결된 노드들은 모두 방문 처리가 됩니다.
- 이때 방문 처리가 되지 않은 노드가 있다면 다른 네트워크에 존재하는 것이기 때문에 네트워크 개수를 하나 늘려주고
- 방문하지 않은 노드를 시작점으로 다시 dfs 혹은 bfs를 돌려줍니다.
- 모든 노드가 방문처리가 될 때까지 반복하면 최종 네트워크 수를 구할 수 있습니다.
