### PR TITLE
[LV3] 경주로 건설

### DIFF
--- a/김은지/[LV3] 경주로 건설.js
+++ b/김은지/[LV3] 경주로 건설.js
@@ -1,0 +1,57 @@
+const DIRECTION = [
+  [1, 0, 0],
+  [0, 1, 1],
+  [-1, 0, 0],
+  [0, -1, 1],
+];
+
+function outOfRange({ row, col, maxRow, maxCol }) {
+  return row < 0 || col < 0 || row >= maxRow || col >= maxCol;
+}
+
+function isWall(status) {
+  return status === 1;
+}
+
+function isCorner(prevDirection, currDirection) {
+  return prevDirection !== currDirection;
+}
+
+function dijsktra(maps, start, end) {
+  const maxRow = maps.length;
+  const maxCol = maps[0].length;
+
+  const distance = Array.from({ length: maxRow }, () => Array.from({ length: maxCol }, () => Array(2).fill(Infinity)));
+
+  distance[start[0]][start[1]][0] = 0;
+  distance[start[0]][start[1]][1] = 0;
+  const pq = [
+    [...start, 0],
+    [...start, 1],
+  ];
+
+  while (pq.length > 0) {
+    pq.sort((a, b) => b[2] - a[2]);
+    const [r, c, cost, direction] = pq.pop();
+
+    if (distance[r][c][direction] > cost) continue;
+    if (r === end[0] && c === end[1]) return distance[r][c][direction];
+
+    for (const [dr, dc, dd] of DIRECTION) {
+      const [nr, nc] = [r + dr, c + dc];
+      if (outOfRange({ row: nr, col: nc, maxRow, maxCol }) || isWall(maps[nr][nc])) continue;
+      const nCost = isCorner(direction, dd) ? distance[r][c][direction] + 600 : distance[r][c][direction] + 100;
+
+      if (distance[nr][nc][dd] > nCost) {
+        distance[nr][nc][dd] = nCost;
+        pq.push([nr, nc, nCost, dd]);
+      }
+    }
+  }
+
+  return -1;
+}
+
+function solution(maps) {
+  return dijsktra(maps, [0, 0, 0], [maps.length - 1, maps[0].length - 1]);
+}

--- a/김은지/[LV3] 경주로 건설.js
+++ b/김은지/[LV3] 경주로 건설.js
@@ -34,7 +34,7 @@ function dijsktra(maps, start, end) {
     pq.sort((a, b) => b[2] - a[2]);
     const [r, c, cost, direction] = pq.pop();
 
-    if (distance[r][c][direction] > cost) continue;
+    if (distance[r][c][direction] < cost) continue;
     if (r === end[0] && c === end[1]) return distance[r][c][direction];
 
     for (const [dr, dc, dd] of DIRECTION) {


### PR DESCRIPTION
> [문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/67259)
> 시간 소요 `40분/100분`
> 시간 복잡도 `/O(N^2)` 

<img width="200" alt="image" src="https://github.com/user-attachments/assets/329ea0e8-3dd9-41cf-85ed-931f7685c6f6">


## 풀이

- 먼저 코너와 직선 도로 간에 드는 비용이 다르기 때문에 가중치가 다르다고 판단하여 다익스트라로 접근하였습니다.
- 여기서 코너를 처리하기 위해 서로 다른 두 방향을 고려하여야 했고, distance 배열을 만들 때 방향을 고려하기 위해 3차원 배열로 구성해주었습니다.

## 기타

처음에는 다익스트라로 접근했으나 최단으로 접근한 노드로 올 때 방향을 고려하지 않고 2차원 배열로 처리하였습니다. -> 같은 노드까지의 접근이 거리는 같으나 방향이 다른 경우 무시가 되는 케이스가 있어서 잘못된 접근이었습니다.