### PR TITLE
[LV2] 전력망을 둘로 나누기

### DIFF
--- a/김현경/[LV2] 전력망을 둘로 나누기.py
+++ b/김현경/[LV2] 전력망을 둘로 나누기.py
@@ -22,12 +22,14 @@ def solution(n, wires):
         graph[a].append(b)
         graph[b].append(a)
     
+    
     res = n
     for a, b in wires:
         graph[a].remove(b)
         graph[b].remove(a)
         
-        res = min(abs(bfs(a, graph) - bfs(b, graph)), res)
+        network_size = bfs(a, graph)
+        res = min(abs(network_size - (n - network_size)), res)
         
         graph[a].append(b)
         graph[b].append(a)

--- a/김현경/[LV2] 전력망을 둘로 나누기.py
+++ b/김현경/[LV2] 전력망을 둘로 나누기.py
@@ -1,0 +1,35 @@
+from collections import deque
+def bfs(start, graph):
+        visited = [False] * len(graph)
+        queue = deque([start])
+        
+        visited[start] = True
+        cnt = 1
+        
+        while queue:
+            node = queue.popleft()
+            
+            for i in graph[node]:
+                if not visited[i]:
+                    queue.append(i)
+                    visited[i] = True
+                    cnt += 1           
+        return cnt
+
+def solution(n, wires):
+    graph = [[] for _ in range(n + 1)]
+    for a, b in wires:
+        graph[a].append(b)
+        graph[b].append(a)
+    
+    res = n
+    for a, b in wires:
+        graph[a].remove(b)
+        graph[b].remove(a)
+        
+        res = min(abs(bfs(a, graph) - bfs(b, graph)), res)
+        
+        graph[a].append(b)
+        graph[b].append(a)
+        
+    return res


### PR DESCRIPTION
## 풀이
- graph 리스트를 초기화하고, 주어진 wires를 순회하며 각 노드의 연결 관계를 저장 (인접 리스트)
- 초기 결과값 res를 n으로 설정
	- 두 전력망 간의 최대 노드 개수 차이는 그래프 전체 노드 개수를 넘지 않으므로, 초기값으로 n을 설정
- wires 리스트를 순회하며, 한 번에 하나씩 간선을 끊는다.
- 간선을 제거한 상태에서 bfs를 호출해 두 서브 전력망의 노드 개수를 구한다.
- bfs는 특정 노드(start)에서 시작하여 연결된 모든 전력망을 탐색하며, 노드 개수를 반환
	- 방문 여부를 기록하기 위해 visited 리스트를 그래프 크기만큼 생성하고, 시작 노드를 queue에 추가
	- 시작 노드를 방문 처리한 후, while문을 통해 queue가 빌 때까지 반복 탐색
	- queue의 앞에서 부터 꺼내서 연결된 모든 노드를 순회
	- 만약 아직 방문하지 않은 노드는 queue에 추가하고 방문 처리 후, cnt 값을 증가
	- 모든 탐색이 끝나면 cnt 반환
- bfs(a)와 bfs(b)의 전력망의 노드 개수 차이를 계산하고 현재의 최소값 res와 비교하여 더 작은 값을 저장
- 다음 순회를 위해 제거 했던 간선을 다시 추가
- 모든 간선을 제거하며 탐색 후, 가장 작은 노드 개수 차이를 반환
<img width="447" alt="전력망" src="https://github.com/user-attachments/assets/75a8e1ed-9ce6-4cb3-b158-a5a4638544c7">
