### PR TITLE
[LV2] 피로도

### DIFF
--- a/김현경/[LV2] 피로도.py
+++ b/김현경/[LV2] 피로도.py
@@ -1,0 +1,31 @@
+def backtrack(k, visited, dungeons, cnt):
+    max_cnt = cnt
+    
+    for i in range(len(dungeons)):
+        if not visited[i] and k >= dungeons[i][0]:
+            visited[i] = True
+            max_cnt = max(max_cnt, backtrack(k - dungeons[i][1], visited, dungeons, cnt + 1))
+            visited[i] = False          
+    return max_cnt
+
+def solution(k, dungeons):
+    visited = [False] * len(dungeons)
+    return backtrack(k, visited, dungeons, 0)
+
+# from itertools import permutations
+# def solution(k, dungeons):
+#     max_cnt = 0
+#     dungeon_permutations = list(permutations(dungeons))
+    
+#     for order in dungeon_permutations:
+#         fatigue = k
+#         cnt = 0
+        
+#         for min_fatigue, use_fatigue in order:
+#             if fatigue >= min_fatigue:
+#                 fatigue -= use_fatigue
+#                 cnt += 1
+#             else:
+#                 break
+#         max_cnt = max(max_cnt, cnt)
+#     return max_cnt


### PR DESCRIPTION
## 풀이
- 방문 처리를 위해 visited를 False로 초기화
- backtrack 함수 호출하여 모든 경우를 탐색
- 초기 cnt는 0으로 시작
- max_cnt를 현재까지 클리어한 던전 수(cnt)로 초기화
- for문으로 dungeons을 순회
- 만약 방문하지 않았고, 현재 피로도가 탐색할 피로도 보다 크다면 던전을 탐험할 수 있음
	- 방문 처리하고 해당 던전을 탐색했으므로 남은 피로도에서 소모 피로도를 빼고, cnt를 1 증가시켜 재귀 호출
	- 재귀 호출 결과로 얻은 값과 현재 max_cnt 값을 비교해서 최대값으로 갱신
- 다른 경로를 탐색을 위해 visited를 다시 False로 방문 처리
- 모든 경로를 탐색한 뒤 최대로 클리어할 수 있는 던전 수 반환
<img width="263" alt="피로도-백트래킹" src="https://github.com/user-attachments/assets/082aa8a5-8600-4f84-bfaf-95afc5677d2a">

## 기타
맨 처음에 순열을 사용해서 풀었는데 문제의 의도가 순열을 사용하는게 아닌 것 같아 다시 풀었습니다.

<img width="290" alt="피로도-순열" src="https://github.com/user-attachments/assets/17c3b038-97a8-4557-b727-a4905e8eadf0">

순열을 사용한 것보다 백트래킹을 사용해서 푼 것이 성능이 조금 더 향상된 것을 확인할 수 있었습니다.
