### PR TITLE
[LV2] 전력망을 둘로 나누기

### DIFF
--- a/조성원/[LV2] 전력망을 둘로 나누기.js
+++ b/조성원/[LV2] 전력망을 둘로 나누기.js
@@ -1,0 +1,41 @@
+function isExcludedWire(current, next, exclude) {
+  return (
+    (current === exclude[0] && next === exclude[1]) ||
+    (current === exclude[1] && next === exclude[0])
+  );
+}
+
+function dfs(graph, current, visited, exclude) {
+  visited[current] = true;
+  let count = 1;
+
+  for (const next of graph[current])
+    if (!visited[next] && !isExcludedWire(current, next, exclude))
+      count += dfs(graph, next, visited, exclude);
+
+  return count;
+}
+
+function buildGraph(n, wires) {
+  const graph = Array.from({ length: n + 1 }, () => []);
+  for (const [a, b] of wires) {
+    graph[a].push(b);
+    graph[b].push(a);
+  }
+  return graph;
+}
+
+function solution(n, wires) {
+  const graph = buildGraph(n, wires);
+  let answer = Number.POSITIVE_INFINITY;
+  const visited = new Array(n + 1);
+
+  for (const wire of wires) {
+    visited.fill(false);
+    const count1 = dfs(graph, wire[0], visited, wire);
+    const count2 = n - count1;
+    answer = Math.min(answer, Math.abs(count1 - count2));
+  }
+
+  return answer;
+}


### PR DESCRIPTION
## Approach

그래프를 생성하고, 완전 탐색으로 각 간선을 순차적으로 제거합니다.
DFS로 분리된 두 그룹의 노드 수를 계산하고, 노드 수 사이의 최소값을 추적합니다.

![CleanShot 2024-11-29 at 22 33 46@2x](https://github.com/user-attachments/assets/3de0b431-96ab-4c1c-9e48-63fe995374cb)