### PR TITLE
[LV3] 사라지는 발판

### DIFF
--- a/조성원/[LV3] 사라지는 발판.js
+++ b/조성원/[LV3] 사라지는 발판.js
@@ -32,7 +32,7 @@ function backtrack(board, aloc, bloc, turn, moveCount) {
     return [false, moveCount];
 
   let canWin = false;
-  let minMovesToWin = Infinity;
+  let minMovesToWin = Number.POSITIVE_INFINITY;
   let maxMovesToLose = 0;
   let hasValidMove = false;
 

--- a/조성원/[LV3] 사라지는 발판.js
+++ b/조성원/[LV3] 사라지는 발판.js
@@ -1,0 +1,73 @@
+const DIRECTIONS = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+];
+
+function isValidMove(board, x, y) {
+  return (
+    x >= 0 &&
+    x < board.length &&
+    y >= 0 &&
+    y < board[0].length &&
+    board[x][y] === 1
+  );
+}
+
+function hasValidMoves(board, x, y) {
+  return DIRECTIONS.some(([dx, dy]) => isValidMove(board, x + dx, y + dy));
+}
+
+function backtrack(board, aloc, bloc, turn, moveCount) {
+  const [currentX, currentY] = turn === "a" ? aloc : bloc;
+
+  if (board[currentX][currentY] === 0) return [false, moveCount];
+
+  if (
+    aloc[0] === bloc[0] &&
+    aloc[1] === bloc[1] &&
+    !hasValidMoves(board, currentX, currentY)
+  )
+    return [false, moveCount];
+
+  let canWin = false;
+  let minMovesToWin = Infinity;
+  let maxMovesToLose = 0;
+  let hasValidMove = false;
+
+  for (const [dx, dy] of DIRECTIONS) {
+    const nextX = currentX + dx;
+    const nextY = currentY + dy;
+
+    if (!isValidMove(board, nextX, nextY)) continue;
+
+    hasValidMove = true;
+    board[currentX][currentY] = 0;
+
+    const [opponentWins, totalMoves] = backtrack(
+      board,
+      turn === "a" ? [nextX, nextY] : aloc,
+      turn === "a" ? bloc : [nextX, nextY],
+      turn === "a" ? "b" : "a",
+      moveCount + 1
+    );
+
+    board[currentX][currentY] = 1;
+
+    if (!opponentWins) {
+      canWin = true;
+      minMovesToWin = Math.min(minMovesToWin, totalMoves);
+    } else {
+      maxMovesToLose = Math.max(maxMovesToLose, totalMoves);
+    }
+  }
+
+  if (!hasValidMove) return [false, moveCount];
+
+  return [canWin, canWin ? minMovesToWin : maxMovesToLose];
+}
+
+function solution(board, aloc, bloc) {
+  return backtrack(board, aloc, bloc, "a", 0)[1];
+}


### PR DESCRIPTION
## Approach
카카오 문제라서 역시 어렵네요...

재귀호출하며 이동하고, 재귀호출 할 때마다 턴이 변경됩니다.
재귀호출이 끝나면 보드 상태를 원래로 돌리고 다음 이동을 고려합니다.
`이길 수 있는 플레이어는 최대한 빨리 승리하도록 플레이하고, 질 수밖에 없는 플레이어는 최대한 오래 버티도록 플레이합니다.` 조건에 따라 이겼을 때는 최소 움직임 수를, 졌을 때는 최대 움직임 수를 반환합니다.

![CleanShot 2024-12-13 at 08 14 49@2x](https://github.com/user-attachments/assets/d0a73472-5cad-44b7-8f18-36bd2c49a6c8)
