### PR TITLE
[LV2] 이진 변환 반복하기

### DIFF
--- a/김현경/[LV2] 이진 변환 반복하기.py
+++ b/김현경/[LV2] 이진 변환 반복하기.py
@@ -1,0 +1,10 @@
+def solution(s):
+    cnt = 0
+    remove_zero = 0
+    
+    while s != '1':
+        cnt += 1
+        remove_zero += s.count('0')
+        s = bin(len(s.replace('0', '')))[2:]
+    
+    return [cnt, remove_zero]


### PR DESCRIPTION
## 풀이
- 이진 변환의 횟수와 제거한 0의 개수를 저장하기 위해 `cnt`, `remove_zero`를 0으로 초기화
- 문자열 `s`가 `1이 될 때까지 반복
	- 이진 변환이 무조건 이루어지기 때문에 `cnt`를 1 증가
	- `s`에서 0의 개수를 카운트해서 `remove_zero`에 더함
	- 0을 제거한 문자열의 길이를 구하고 그 길이를 2진수로 변환
	- `bin()` 함수로 변환하면 앞에 `'ob'`가 나오기 때문에 `[2:]` 슬라이싱으로 제거
- `[cnt, remove_zero]` 반환

<img width="274" alt="이진변환반복하기" src="https://github.com/user-attachments/assets/f27d6f4f-81f3-4eca-9e49-94bcc045a0bd" />
