### PR TITLE
[LV2] 롤케이크 자르기

### DIFF
--- a/김현경/[LV2] 롤케이크 자르기.py
+++ b/김현경/[LV2] 롤케이크 자르기.py
@@ -1,0 +1,21 @@
+def solution(topping):
+    cnt = 0
+    chulsu = {}
+    for t in topping:
+        if t in chulsu:
+            chulsu[t] += 1
+        else:
+            chulsu[t] = 1
+    
+    brother = {}
+    for t in topping:
+        if len(brother) == len(chulsu):
+            cnt += 1
+        if t not in brother:
+            brother[t] = 1
+            
+        chulsu[t] -= 1
+        if chulsu[t] == 0:
+            del chulsu[t]
+            
+    return cnt


### PR DESCRIPTION
## 풀이
- `chulsu` 딕셔너리를 사용하여 `topping` 리스트에 있는 각 토핑의 개수 구함
- `brother` 딕셔너리를 사용하여 동생이 받은 토핑을 하나씩 추가
- 동생이 받은 토핑의 개수와 철수가 받은 토핑의 개수가 같아지면 공평하게 나눈 것이므로 `cnt` 1 증가
- 동생에게 토핑을 하나씩 추가하면 철수는 그 토핑을 하나씩 빼서 `chulsu` 딕셔너리 갱신 
- 철수와 동생의 토핑 개수가 같을 때마다 `cnt`를 증가
- `cnt`를 반환

<img src="https://github.com/user-attachments/assets/301cc34b-21b5-445d-bb33-612cd039ca6e" width="300"/>
